### PR TITLE
feat: add -s/--status flag for status bars and coding agents

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -20,6 +20,7 @@ Built for humans and agents.
 - ✨ Highlights current + next Sehar/Iftar with countdown
 - 🗓 `-a, --all` for complete Ramadan month
 - 🔢 `-n, --number` for a specific roza day
+- 📟 `-s, --status` single-line next event for status bars and coding agents
 - 🧪 Custom first roza override (`--first-roza-date`)
 - 🧹 One-command reset (`reset`)
 
@@ -65,6 +66,11 @@ roza "San Francisco" -a
 # Specific roza.
 roza -n 10
 roza "dera ghazi khan" -n 10
+
+# Status line (next event only — for status bars, coding agents).
+roza -s
+roza --status
+roza -s --city Lahore
 
 # Set custom first roza date (stored).
 roza --first-roza-date 2026-02-19
@@ -112,6 +118,7 @@ Global/main command flags (`ramadan-cli [city]`):
 | `-n, --number <1-30>` | `number` | none | Show specific roza |
 | `-p, --plain` | `boolean` | `false` | Plain text output without ASCII banner |
 | `-j, --json` | `boolean` | `false` | JSON-only output for scripts |
+| `-s, --status` | `boolean` | `false` | Single-line next event output for status bars and coding agents |
 | `--first-roza-date <YYYY-MM-DD>` | `string` | stored/API | Persist custom first roza date |
 | `--clear-first-roza-date` | `boolean` | `false` | Clear custom first roza date and use API Ramadan date |
 | `-v, --version` | `boolean` | n/a | Print version only |
@@ -162,7 +169,7 @@ Reset command:
 ## Interactivity and Safety
 
 - On first run (TTY), CLI launches interactive setup with Clack prompts.
-- If `--json` is used and no config exists, interactive setup is skipped.
+- If `--json` or `--status` is used and no config exists, interactive setup is skipped.
 - Config changes are explicit via `config`, `reset`, and first-roza flags.
 - No stdin input contract yet. Input is args/flags only.
 

--- a/skills/skill.md
+++ b/skills/skill.md
@@ -17,7 +17,7 @@ Run, validate, and debug `ramadan-cli` safely and reproducibly.
 Primary user mode:
 
 - Human-first interactive defaults
-- Script-friendly deterministic modes via flags (`--json`, `--plain`, `config`)
+- Script-friendly deterministic modes via flags (`--json`, `--plain`, `--status`, `config`)
 
 Command surface:
 
@@ -36,6 +36,8 @@ ramadan-cli
 ramadan-cli sf
 ramadan-cli -a
 ramadan-cli -n 10
+ramadan-cli -s
+ramadan-cli -s --city Lahore
 ramadan-cli reset
 ramadan-cli config --show
 ```
@@ -146,6 +148,8 @@ Expected:
 - `ramadan-cli sf --json`
 - `ramadan-cli sf --plain`
 - `ramadan-cli sf -a` (includes `← current` / `← next` row annotations)
+- `ramadan-cli -s` (single line: `Iftar in 2h 30m` or `Sehar in 8h 15m`)
+- `ramadan-cli -s --city Lahore` (status with one-off city)
 
 ### Non-interactive readiness
 
@@ -153,3 +157,4 @@ Expected:
 - `ramadan-cli config --clear`
 - `ramadan-cli config --method 2 --school 0`
 - `ramadan-cli --clear-first-roza-date`
+- `ramadan-cli -s` (always non-interactive; silent failure)

--- a/skills/spec.md
+++ b/skills/spec.md
@@ -59,6 +59,7 @@ Global/main flags:
 - `-n, --number <1-30>`
 - `-p, --plain`
 - `-j, --json`
+- `-s, --status`
 - `--first-roza-date <YYYY-MM-DD>`
 - `--clear-first-roza-date`
 - `-v, --version`
@@ -87,6 +88,7 @@ Config flags (`ramadan-cli config`):
 - `--all` and `--number` are mutually exclusive.
 - `--clear-first-roza-date` clears persisted first roza override immediately.
 - City argument/`--city` on main command is one-off and does not persist as default.
+- `--status` outputs a single line (`{next event} in {countdown}`) to `stdout` and exits; no spinner, no banner, no table, no interactive setup.
 
 ## 3.2 Input Sources
 
@@ -118,7 +120,7 @@ When no saved location exists and command is interactive (TTY), CLI must prompt 
 
 Setup saves config for future runs.
 
-If `--json` is used, CLI must skip interactive setup.
+If `--json` or `--status` is used, CLI must skip interactive setup.
 
 ## 6. Query Resolution Rules
 
@@ -169,6 +171,13 @@ JSON mode:
 - no interactive prompt flow
 - failures are emitted to `stderr` as structured JSON:
   - `{"ok":false,"error":{"code":"...","message":"..."}}`
+
+Status mode (`-s, --status`):
+
+- single line to `stdout`: e.g. `Iftar in 2h 30m` or `Sehar in 8h 15m`
+- no banner, no table, no spinner, no interactive setup
+- silent on failure (exits 0 with no output)
+- accepts `--city` for one-off location override
 
 Streams:
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,6 +10,7 @@ interface RootOptions {
 	readonly number?: number | undefined;
 	readonly plain?: boolean | undefined;
 	readonly json?: boolean | undefined;
+	readonly status?: boolean | undefined;
 	readonly firstRozaDate?: string | undefined;
 	readonly clearFirstRozaDate?: boolean | undefined;
 }
@@ -60,6 +61,7 @@ program
 	)
 	.option('-p, --plain', 'Plain text output')
 	.option('-j, --json', 'JSON output')
+	.option('-s, --status', 'Status line output (next event only, for status bars)')
 	.option(
 		'--first-roza-date <YYYY-MM-DD>',
 		'Set and use a custom first roza date'
@@ -75,6 +77,7 @@ program
 			rozaNumber: opts.number,
 			plain: opts.plain,
 			json: opts.json,
+			status: opts.status,
 			firstRozaDate: opts.firstRozaDate,
 			clearFirstRozaDate: opts.clearFirstRozaDate,
 		});


### PR DESCRIPTION
## Summary

- Adds `-s, --status` flag that outputs a single minimal line showing the next event and countdown
- Output examples: `Iftar in 2h 30m`, `Sehar in 8h 15m`, `Fast starts in 45m`
- Designed for embedding in terminal status bars, tmux, starship, coding agent status lines, etc.

## Behavior

- No spinner, banner, table, or interactive setup — one line and done
- Silent on failure (exits cleanly, no error noise in status bars)
- Accepts `--city` for one-off location: `roza -s --city Lahore`
- Skips interactive first-run setup (same as `--json`)

## Test plan

- [ ] `roza -s` outputs a single line like `Iftar in 2h 30m`
- [ ] `roza --status` same output
- [ ] `roza -s --city Lahore` works with one-off city
- [ ] No spinner or banner output
- [ ] Works correctly in all four states: before Ramadan, sehar window, roza in progress, after iftar

PR by [CommandCode.ai](https://commandcode.ai)