### PR TITLE
feat: Implement internationalization (i18n) with English and Indonesian language

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -23,6 +23,7 @@ Built for humans and agents.
 - 📟 `-s, --status` single-line next event for status bars and coding agents
 - 🧪 Custom first roza override (`--first-roza-date`)
 - 🧹 One-command reset (`reset`)
+- 🌍 Multilanguage support (English, Bahasa Indonesia)
 
 [![ramadan-cli](https://raw.githubusercontent.com/ahmadawais/ramadan-cli/refs/heads/main/.github/ramadan.gif)](https://x.com/MrAhmadAwais/)
 
@@ -81,6 +82,13 @@ roza --clear-first-roza-date
 # Reset saved config (location + settings + overrides).
 roza reset
 
+# Switch language for one invocation.
+roza --lang id
+roza --lang en lahore
+
+# Save preferred language.
+ramadan-cli config --lang id
+
 # Non-interactive config (no prompts).
 ramadan-cli config --city "San Francisco" --country "United States" --method 2 --school 0 --timezone "America/Los_Angeles"
 ramadan-cli config --show
@@ -121,6 +129,7 @@ Global/main command flags (`ramadan-cli [city]`):
 | `-s, --status` | `boolean` | `false` | Single-line next event output for status bars and coding agents |
 | `--first-roza-date <YYYY-MM-DD>` | `string` | stored/API | Persist custom first roza date |
 | `--clear-first-roza-date` | `boolean` | `false` | Clear custom first roza date and use API Ramadan date |
+| `-l, --lang <lang>` | `string` | saved/`en` | Set display language (`en`, `id`) for one invocation |
 | `-v, --version` | `boolean` | n/a | Print version only |
 | `-h, --help` | `boolean` | n/a | Show help |
 
@@ -135,6 +144,7 @@ Config flags (`ramadan-cli config`):
 | `--method <id>` | `number` | Save method (`0..23`) |
 | `--school <id>` | `number` | Save school (`0=Shafi`, `1=Hanafi`) |
 | `--timezone <timezone>` | `string` | Save timezone |
+| `--lang <lang>` | `string` | Save display language (`en`, `id`) |
 | `--show` | `boolean` | Print saved config |
 | `--clear` | `boolean` | Clear saved config |
 
@@ -186,7 +196,16 @@ Resolution behavior:
 - One-off city arg/flag wins for that invocation but is not persisted.
 - `--clear-first-roza-date` takes precedence over `--first-roza-date` if both are provided.
 - Recommended method/school are auto-applied when using default/unset settings.
+- `--lang` flag wins over saved language for that invocation.
 - `RAMADAN_CLI_CONFIG_DIR` controls where config is stored (useful for agent/test isolation).
+
+## Language
+
+Supported languages: **English** (`en`), **Bahasa Indonesia** (`id`).
+
+- First-run setup prompts you to pick a language.
+- Use `-l, --lang <lang>` on any command for a one-off switch.
+- Use `ramadan-cli config --lang id` to persist your preference.
 
 ## Development
 

--- a/src/__tests__/i18n.test.ts
+++ b/src/__tests__/i18n.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { getLocale, setLocale, t } from '../i18n/index.js';
+
+describe('i18n', () => {
+	afterEach(() => {
+		setLocale('en');
+	});
+
+	it('defaults to English locale', () => {
+		expect(getLocale()).toBe('en');
+		expect(t('tableHeaderRoza')).toBe('Roza');
+	});
+
+	it('switches to Indonesian locale', () => {
+		setLocale('id');
+		expect(getLocale()).toBe('id');
+		expect(t('tableHeaderRoza')).toBe('Puasa ke-');
+		expect(t('tableHeaderSehar')).toBe('Sahur');
+		expect(t('tableHeaderIftar')).toBe('Berbuka');
+	});
+
+	it('switches back to English', () => {
+		setLocale('id');
+		setLocale('en');
+		expect(getLocale()).toBe('en');
+		expect(t('tableHeaderRoza')).toBe('Roza');
+	});
+
+	it('ignores unsupported languages', () => {
+		setLocale('fr');
+		expect(getLocale()).toBe('en');
+		expect(t('tableHeaderRoza')).toBe('Roza');
+	});
+
+	it('interpolates template parameters', () => {
+		expect(t('titleAllDays', { year: 1447 })).toBe('Ramadan 1447 (All Days)');
+		setLocale('id');
+		expect(t('titleAllDays', { year: 1447 })).toBe('Ramadan 1447 (Semua Hari)');
+	});
+
+	it('interpolates multiple params', () => {
+		expect(t('setupDetected', { city: 'Lahore', country: 'Pakistan' })).toBe(
+			'Detected: Lahore, Pakistan'
+		);
+		setLocale('id');
+		expect(t('setupDetected', { city: 'Jakarta', country: 'Indonesia' })).toBe(
+			'Terdeteksi: Jakarta, Indonesia'
+		);
+	});
+
+	it('translates highlight states in Indonesian', () => {
+		setLocale('id');
+		expect(t('highlightSeharWindowOpen')).toBe('Waktu sahur terbuka');
+		expect(t('highlightRozaInProgress')).toBe('Sedang berpuasa');
+		expect(t('highlightIftar')).toBe('Berbuka');
+		expect(t('highlightIftarTime')).toBe('Waktu berbuka');
+	});
+
+	it('translates config messages in Indonesian', () => {
+		setLocale('id');
+		expect(t('configCleared')).toBe('Konfigurasi dihapus.');
+		expect(t('configUpdated')).toBe('Konfigurasi diperbarui.');
+		expect(t('configReset')).toBe('Konfigurasi direset.');
+	});
+
+	it('translates banner texts in Indonesian', () => {
+		setLocale('id');
+		expect(t('bannerTagline')).toBe('Sahur • Berbuka • Jadwal Ramadan');
+	});
+
+	it('translates CLI description in Indonesian', () => {
+		setLocale('id');
+		expect(t('cliDescription')).toBe(
+			'CLI Ramadan untuk jadwal Sahur dan Berbuka'
+		);
+	});
+});

--- a/src/__tests__/ramadan.test.ts
+++ b/src/__tests__/ramadan.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import {
 	getJsonErrorCode,
-	toJsonErrorPayload,
 	getRozaNumberFromStartDate,
 	getTargetRamadanYear,
 	normalizeCityAlias,
 	to12HourTime,
+	toJsonErrorPayload,
 } from '../commands/ramadan.js';
 
 const samplePrayerData = (month: number, year: string) => ({
@@ -125,9 +125,9 @@ describe('normalizeCityAlias', () => {
 
 describe('json error payload', () => {
 	it('maps known failures to stable error codes', () => {
-		expect(getJsonErrorCode('Could not fetch prayer times. timingsByAddress failed')).toBe(
-			'PRAYER_TIMES_FETCH_FAILED'
-		);
+		expect(
+			getJsonErrorCode('Could not fetch prayer times. timingsByAddress failed')
+		).toBe('PRAYER_TIMES_FETCH_FAILED');
 		expect(getJsonErrorCode('Use either --all or --number, not both.')).toBe(
 			'INVALID_FLAG_COMBINATION'
 		);

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,0 +1,42 @@
+import en from './locales/en.js';
+import id from './locales/id.js';
+
+export type Locale = typeof en;
+export type LocaleKey = keyof Locale;
+export type SupportedLang = 'en' | 'id';
+
+const locales: Readonly<Record<SupportedLang, Locale>> = { en, id };
+
+let currentLang: SupportedLang = 'en';
+let currentLocale: Locale = en;
+
+export const SUPPORTED_LANGUAGES: ReadonlyArray<SupportedLang> = ['en', 'id'];
+
+export const isSupportedLang = (value: string): value is SupportedLang =>
+	SUPPORTED_LANGUAGES.includes(value as SupportedLang);
+
+export const setLocale = (lang: string): void => {
+	if (!isSupportedLang(lang)) {
+		return;
+	}
+
+	currentLang = lang;
+	currentLocale = locales[lang];
+};
+
+export const getLocale = (): SupportedLang => currentLang;
+
+export const t = (
+	key: LocaleKey,
+	params?: Readonly<Record<string, string | number>>
+): string => {
+	let value: string = currentLocale[key] ?? key;
+
+	if (params) {
+		for (const [paramKey, paramValue] of Object.entries(params)) {
+			value = value.replaceAll(`{${paramKey}}`, String(paramValue));
+		}
+	}
+
+	return value;
+};

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1,0 +1,157 @@
+const en = {
+	// CLI descriptions
+	cliDescription: 'Ramadan CLI for Sehar and Iftar timings',
+	cliCityArg: 'City name (e.g. "San Francisco", "sf", "Vancouver", "Lahore")',
+	cliCityOption: 'City',
+	cliAllOption: 'Show complete Ramadan month',
+	cliNumberOption: 'Show a specific roza day (1-30)',
+	cliPlainOption: 'Plain text output',
+	cliJsonOption: 'JSON output',
+	cliStatusOption: 'Status line output (next event only, for status bars)',
+	cliFirstRozaDateOption: 'Set and use a custom first roza date',
+	cliClearFirstRozaDateOption:
+		'Clear custom first roza date and use API Ramadan date',
+	cliLangOption: 'Set display language (en, id)',
+	cliResetDescription: 'Clear saved Ramadan CLI configuration',
+	cliConfigDescription:
+		'Configure saved Ramadan CLI settings (non-interactive)',
+	cliConfigCityOption: 'Save city',
+	cliConfigCountryOption: 'Save country',
+	cliConfigLatitudeOption: 'Save latitude (-90 to 90)',
+	cliConfigLongitudeOption: 'Save longitude (-180 to 180)',
+	cliConfigMethodOption: 'Save calculation method (0-23)',
+	cliConfigSchoolOption: 'Save school (0=Shafi, 1=Hanafi)',
+	cliConfigTimezoneOption: 'Save timezone (e.g., America/Los_Angeles)',
+	cliConfigLangOption: 'Save display language (en, id)',
+	cliConfigShowOption: 'Show current configuration',
+	cliConfigClearOption: 'Clear saved configuration',
+	cliRozaNumberError: 'Roza number must be between 1 and 30.',
+
+	// Setup prompts
+	setupIntro: '🌙 Ramadan CLI Setup',
+	setupDetecting: '🌙 Detecting your location...',
+	setupDetected: 'Detected: {city}, {country}',
+	setupDetectFailed: 'Could not detect location',
+	setupEnterCity: 'Enter your city',
+	setupCityPlaceholder: 'e.g., Lahore',
+	setupCityRequired: 'City is required.',
+	setupInvalidCity: 'Invalid city value.',
+	setupEnterCountry: 'Enter your country',
+	setupCountryPlaceholder: 'e.g., Pakistan',
+	setupCountryRequired: 'Country is required.',
+	setupInvalidCountry: 'Invalid country value.',
+	setupResolvingCity: '🌙 Resolving city details...',
+	setupDetectedTimezone: 'Detected timezone: {timezone}',
+	setupTimezoneDetectFailed: 'Could not detect timezone for this city',
+	setupSelectMethod: 'Select calculation method',
+	setupInvalidMethod: 'Invalid method selection.',
+	setupSelectSchool: 'Select Asr school',
+	setupInvalidSchool: 'Invalid school selection.',
+	setupTimezonePreference: 'Timezone preference',
+	setupUseDetectedTimezone: 'Use detected timezone ({timezone})',
+	setupSetCustomTimezone: 'Set custom timezone',
+	setupSkipTimezone: 'Do not set timezone override',
+	setupEnterTimezone: 'Enter timezone',
+	setupTimezonePlaceholder: 'e.g., Asia/Karachi',
+	setupTimezoneRequired: 'Timezone is required.',
+	setupInvalidTimezone: 'Invalid timezone value.',
+	setupComplete: '🌙 Setup complete.',
+	setupCancelled: 'Setup cancelled',
+	setupSelectLanguage: 'Select display language',
+
+	// Setup - method/school labels
+	setupRecommended: '(Recommended)',
+	setupBasedOnCountry: 'Based on your country',
+	setupHanafi: 'Hanafi',
+	setupShafi: 'Shafi',
+	setupLaterAsrTiming: 'Later Asr timing',
+	setupStandardAsrTiming: 'Standard Asr timing',
+
+	// Table headers
+	tableHeaderRoza: 'Roza',
+	tableHeaderSehar: 'Sehar',
+	tableHeaderIftar: 'Iftar',
+	tableHeaderDate: 'Date',
+	tableHeaderHijri: 'Hijri',
+
+	// Highlight / status labels
+	highlightBeforeRozaDay: 'Before roza day',
+	highlightFirstSehar: 'First Sehar',
+	highlightSeharWindowOpen: 'Sehar window open',
+	highlightRozaStartsFajr: 'Roza starts (Fajr)',
+	highlightRozaInProgress: 'Roza in progress',
+	highlightIftar: 'Iftar',
+	highlightIftarTime: 'Iftar time',
+	highlightNextDaySehar: 'Next day Sehar',
+
+	// Row annotations
+	annotationCurrent: '← current',
+	annotationNext: '← next',
+
+	// Status line labels
+	statusSehar: 'Sehar',
+	statusFastStarts: 'Fast starts',
+	statusIn: 'in',
+
+	// Output titles
+	titleAllDays: 'Ramadan {year} (All Days)',
+	titleRozaSeharIftar: 'Roza {roza} Sehar/Iftar',
+	titleTodaySeharIftar: 'Today Sehar/Iftar',
+
+	// Output labels
+	outputStatus: 'Status:',
+	outputUpNext: 'Up next:',
+	outputIn: 'in',
+	outputFooter: 'Sehar uses Fajr. Iftar uses Maghrib.',
+
+	// Banner
+	bannerLabel: '🌙 Ramadan CLI',
+	bannerTagline: 'Sehar • Iftar • Ramadan timings',
+
+	// Spinner
+	spinnerFetching: 'Fetching Ramadan timings...',
+	spinnerFailed: 'Failed to fetch Ramadan timings',
+
+	// Config command
+	configCleared: 'Configuration cleared.',
+	configUpdated: 'Configuration updated.',
+	configNoUpdates:
+		'No config updates provided. Use `ramadan-cli config --show` to inspect.',
+	configCurrentTitle: 'Current configuration:',
+	configReset: 'Configuration reset.',
+
+	// Config labels
+	configLabelCity: 'City',
+	configLabelCountry: 'Country',
+	configLabelLatitude: 'Latitude',
+	configLabelLongitude: 'Longitude',
+	configLabelMethod: 'Method',
+	configLabelSchool: 'School',
+	configLabelTimezone: 'Timezone',
+	configLabelFirstRozaDate: 'First Roza Date',
+	configLabelLanguage: 'Language',
+
+	// Errors
+	errorInvalidFirstRozaDate: 'Invalid first roza date. Use YYYY-MM-DD.',
+	errorUseAllOrNumber: 'Use either --all or --number, not both.',
+	errorCouldNotFetchPrayer: 'Could not fetch prayer times. {details}',
+	errorCouldNotFetchCalendar: 'Could not fetch Ramadan calendar. {details}',
+	errorCouldNotDetectLocation:
+		'Could not detect location. Pass a city like `ramadan-cli "Lahore"`.',
+	errorCouldNotFindRoza: 'Could not find roza {number} timings.',
+	errorCouldNotParseDate:
+		'Could not parse Gregorian date from prayer response.',
+	errorCouldNotDetermineFirstRoza: 'Could not determine first roza date.',
+	errorCouldNotDetermineRoza: 'Could not determine roza number.',
+	errorCouldNotFindFirstDay: 'Could not find the first day of Ramadan.',
+	errorInvalidLatitude: 'Invalid latitude.',
+	errorInvalidLongitude: 'Invalid longitude.',
+	errorInvalidMethod: 'Invalid method.',
+	errorInvalidSchool: 'Invalid school.',
+
+	// Language names
+	langEnglish: 'English',
+	langIndonesian: 'Bahasa Indonesia',
+};
+
+export default en;

--- a/src/i18n/locales/id.ts
+++ b/src/i18n/locales/id.ts
@@ -1,0 +1,163 @@
+import type { Locale } from '../index.js';
+
+const id: Locale = {
+	// CLI descriptions
+	cliDescription: 'CLI Ramadan untuk jadwal Sahur dan Berbuka',
+	cliCityArg: 'Nama kota (misal "Jakarta", "Surabaya", "Bandung", "Medan")',
+	cliCityOption: 'Kota',
+	cliAllOption: 'Tampilkan seluruh bulan Ramadan',
+	cliNumberOption: 'Tampilkan hari puasa tertentu (1-30)',
+	cliPlainOption: 'Output teks biasa',
+	cliJsonOption: 'Output JSON',
+	cliStatusOption:
+		'Output satu baris (hanya jadwal berikutnya, untuk status bar)',
+	cliFirstRozaDateOption: 'Atur dan gunakan tanggal puasa pertama kustom',
+	cliClearFirstRozaDateOption:
+		'Hapus tanggal puasa pertama kustom dan gunakan tanggal Ramadan dari API',
+	cliLangOption: 'Atur bahasa tampilan (en, id)',
+	cliResetDescription: 'Hapus konfigurasi Ramadan CLI yang tersimpan',
+	cliConfigDescription: 'Konfigurasi pengaturan Ramadan CLI (non-interaktif)',
+	cliConfigCityOption: 'Simpan kota',
+	cliConfigCountryOption: 'Simpan negara',
+	cliConfigLatitudeOption: 'Simpan lintang (-90 s/d 90)',
+	cliConfigLongitudeOption: 'Simpan bujur (-180 s/d 180)',
+	cliConfigMethodOption: 'Simpan metode perhitungan (0-23)',
+	cliConfigSchoolOption: 'Simpan mazhab (0=Syafii, 1=Hanafi)',
+	cliConfigTimezoneOption: 'Simpan zona waktu (misal Asia/Jakarta)',
+	cliConfigLangOption: 'Simpan bahasa tampilan (en, id)',
+	cliConfigShowOption: 'Tampilkan konfigurasi saat ini',
+	cliConfigClearOption: 'Hapus konfigurasi tersimpan',
+	cliRozaNumberError: 'Nomor puasa harus antara 1 dan 30.',
+
+	// Setup prompts
+	setupIntro: '🌙 Pengaturan Ramadan CLI',
+	setupDetecting: '🌙 Mendeteksi lokasi Anda...',
+	setupDetected: 'Terdeteksi: {city}, {country}',
+	setupDetectFailed: 'Tidak dapat mendeteksi lokasi',
+	setupEnterCity: 'Masukkan kota Anda',
+	setupCityPlaceholder: 'misal Jakarta',
+	setupCityRequired: 'Kota wajib diisi.',
+	setupInvalidCity: 'Nilai kota tidak valid.',
+	setupEnterCountry: 'Masukkan negara Anda',
+	setupCountryPlaceholder: 'misal Indonesia',
+	setupCountryRequired: 'Negara wajib diisi.',
+	setupInvalidCountry: 'Nilai negara tidak valid.',
+	setupResolvingCity: '🌙 Mencari detail kota...',
+	setupDetectedTimezone: 'Zona waktu terdeteksi: {timezone}',
+	setupTimezoneDetectFailed: 'Tidak dapat mendeteksi zona waktu untuk kota ini',
+	setupSelectMethod: 'Pilih metode perhitungan',
+	setupInvalidMethod: 'Pilihan metode tidak valid.',
+	setupSelectSchool: 'Pilih mazhab Ashar',
+	setupInvalidSchool: 'Pilihan mazhab tidak valid.',
+	setupTimezonePreference: 'Preferensi zona waktu',
+	setupUseDetectedTimezone: 'Gunakan zona waktu terdeteksi ({timezone})',
+	setupSetCustomTimezone: 'Atur zona waktu kustom',
+	setupSkipTimezone: 'Jangan atur zona waktu',
+	setupEnterTimezone: 'Masukkan zona waktu',
+	setupTimezonePlaceholder: 'misal Asia/Jakarta',
+	setupTimezoneRequired: 'Zona waktu wajib diisi.',
+	setupInvalidTimezone: 'Nilai zona waktu tidak valid.',
+	setupComplete: '🌙 Pengaturan selesai.',
+	setupCancelled: 'Pengaturan dibatalkan',
+	setupSelectLanguage: 'Pilih bahasa tampilan',
+
+	// Setup - method/school labels
+	setupRecommended: '(Direkomendasikan)',
+	setupBasedOnCountry: 'Berdasarkan negara Anda',
+	setupHanafi: 'Hanafi',
+	setupShafi: 'Syafii',
+	setupLaterAsrTiming: 'Waktu Ashar lebih akhir',
+	setupStandardAsrTiming: 'Waktu Ashar standar',
+
+	// Table headers
+	tableHeaderRoza: 'Puasa ke-',
+	tableHeaderSehar: 'Sahur',
+	tableHeaderIftar: 'Berbuka',
+	tableHeaderDate: 'Tanggal',
+	tableHeaderHijri: 'Hijriyah',
+
+	// Highlight / status labels
+	highlightBeforeRozaDay: 'Sebelum hari puasa',
+	highlightFirstSehar: 'Sahur pertama',
+	highlightSeharWindowOpen: 'Waktu sahur terbuka',
+	highlightRozaStartsFajr: 'Puasa dimulai (Subuh)',
+	highlightRozaInProgress: 'Sedang berpuasa',
+	highlightIftar: 'Berbuka',
+	highlightIftarTime: 'Waktu berbuka',
+	highlightNextDaySehar: 'Sahur hari berikutnya',
+
+	// Row annotations
+	annotationCurrent: '← hari ini',
+	annotationNext: '← berikutnya',
+
+	// Status line labels
+	statusSehar: 'Sahur',
+	statusFastStarts: 'Puasa dimulai',
+	statusIn: 'dalam',
+
+	// Output titles
+	titleAllDays: 'Ramadan {year} (Semua Hari)',
+	titleRozaSeharIftar: 'Puasa ke-{roza} Sahur/Berbuka',
+	titleTodaySeharIftar: 'Sahur/Berbuka Hari Ini',
+
+	// Output labels
+	outputStatus: 'Status:',
+	outputUpNext: 'Berikutnya:',
+	outputIn: 'dalam',
+	outputFooter:
+		'Sahur menggunakan waktu Subuh. Berbuka menggunakan waktu Maghrib.',
+
+	// Banner
+	bannerLabel: '🌙 Ramadan CLI',
+	bannerTagline: 'Sahur • Berbuka • Jadwal Ramadan',
+
+	// Spinner
+	spinnerFetching: 'Mengambil jadwal Ramadan...',
+	spinnerFailed: 'Gagal mengambil jadwal Ramadan',
+
+	// Config command
+	configCleared: 'Konfigurasi dihapus.',
+	configUpdated: 'Konfigurasi diperbarui.',
+	configNoUpdates:
+		'Tidak ada pembaruan konfigurasi. Gunakan `ramadan-cli config --show` untuk melihat.',
+	configCurrentTitle: 'Konfigurasi saat ini:',
+	configReset: 'Konfigurasi direset.',
+
+	// Config labels
+	configLabelCity: 'Kota',
+	configLabelCountry: 'Negara',
+	configLabelLatitude: 'Lintang',
+	configLabelLongitude: 'Bujur',
+	configLabelMethod: 'Metode',
+	configLabelSchool: 'Mazhab',
+	configLabelTimezone: 'Zona Waktu',
+	configLabelFirstRozaDate: 'Tanggal Puasa Pertama',
+	configLabelLanguage: 'Bahasa',
+
+	// Errors
+	errorInvalidFirstRozaDate:
+		'Tanggal puasa pertama tidak valid. Gunakan format YYYY-MM-DD.',
+	errorUseAllOrNumber: 'Gunakan --all atau --number, jangan keduanya.',
+	errorCouldNotFetchPrayer: 'Tidak dapat mengambil waktu shalat. {details}',
+	errorCouldNotFetchCalendar:
+		'Tidak dapat mengambil kalender Ramadan. {details}',
+	errorCouldNotDetectLocation:
+		'Tidak dapat mendeteksi lokasi. Masukkan kota seperti `ramadan-cli "Jakarta"`.',
+	errorCouldNotFindRoza: 'Tidak dapat menemukan jadwal puasa ke-{number}.',
+	errorCouldNotParseDate:
+		'Tidak dapat memproses tanggal Masehi dari respons shalat.',
+	errorCouldNotDetermineFirstRoza:
+		'Tidak dapat menentukan tanggal puasa pertama.',
+	errorCouldNotDetermineRoza: 'Tidak dapat menentukan nomor puasa.',
+	errorCouldNotFindFirstDay: 'Tidak dapat menemukan hari pertama Ramadan.',
+	errorInvalidLatitude: 'Lintang tidak valid.',
+	errorInvalidLongitude: 'Bujur tidak valid.',
+	errorInvalidMethod: 'Metode tidak valid.',
+	errorInvalidSchool: 'Mazhab tidak valid.',
+
+	// Language names
+	langEnglish: 'English',
+	langIndonesian: 'Bahasa Indonesia',
+};
+
+export default id;

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,3 +3,4 @@ export * from './geo.js';
 export * from './ramadan-config.js';
 export * from './recommendations.js';
 export * from './commands/index.js';
+export * from './i18n/index.js';

--- a/src/ramadan-config.ts
+++ b/src/ramadan-config.ts
@@ -1,6 +1,7 @@
 import Conf from 'conf';
 import { z } from 'zod';
 import type { GeoLocation } from './geo.js';
+import type { SupportedLang } from './i18n/index.js';
 import {
 	getRecommendedMethod,
 	getRecommendedSchool,
@@ -16,6 +17,7 @@ interface RamadanConfigStore {
 	readonly timezone?: string | undefined;
 	readonly firstRozaDate?: string | undefined;
 	readonly format24h?: boolean | undefined;
+	readonly language?: string | undefined;
 }
 
 interface StoredLocation {
@@ -39,6 +41,7 @@ const SharedConfigSchema = z.object({
 	method: z.number().optional(),
 	school: z.number().optional(),
 	timezone: z.string().optional(),
+	language: z.string().optional(),
 	firstRozaDate: z
 		.string()
 		.regex(/^\d{4}-\d{2}-\d{2}$/)
@@ -188,6 +191,19 @@ export const clearStoredFirstRozaDate = (): void => {
 export const clearRamadanConfig = (): void => {
 	sharedConfig.clear();
 	legacyAzaanConfig.clear();
+};
+
+export const getStoredLanguage = (): SupportedLang => {
+	const store = getValidatedStore();
+	const lang = store.language;
+	if (lang === 'id') {
+		return 'id';
+	}
+	return 'en';
+};
+
+export const setStoredLanguage = (language: SupportedLang): void => {
+	sharedConfig.set('language', language);
 };
 
 const maybeSetRecommendedMethod = (country: string): void => {

--- a/src/ui/banner.ts
+++ b/src/ui/banner.ts
@@ -1,4 +1,5 @@
 import pc from 'picocolors';
+import { t } from '../i18n/index.js';
 import { MOON_EMOJI, ramadanGreen } from './theme.js';
 
 const ANSI_SHADOW = `
@@ -18,13 +19,11 @@ const ANSI_COMPACT = `
 ██   ██ ██   ██ ██      ██ ██   ██ ██████  ██   ██ ██   ████
 `;
 
-const tagLine = 'Sehar • Iftar • Ramadan timings';
-
 export const getBanner = (): string => {
 	const width = process.stdout.columns ?? 80;
 	const art = width >= 120 ? ANSI_SHADOW : ANSI_COMPACT;
 	const artColor = ramadanGreen(art.trimEnd());
-	const lead = ramadanGreen(`  ${MOON_EMOJI} Ramadan CLI`);
-	const tag = pc.dim(`  ${tagLine}`);
+	const lead = ramadanGreen(`  ${t('bannerLabel')}`);
+	const tag = pc.dim(`  ${t('bannerTagline')}`);
 	return `\n${artColor}\n${lead}\n${tag}\n`;
 };


### PR DESCRIPTION
## Summary

Adds internationalization (i18n) support to ramadan-cli using a lightweight typed dictionary pattern — no external i18n dependencies added.

### Languages
- 🇬🇧 English (default)
- 🇮🇩 Bahasa Indonesia

## Changes

### New files
- [src/i18n/index.ts](cci:7://file:///Users/zakyyudha/Projects/ramadan-cli/src/i18n/index.ts:0:0-0:0) — Core i18n module with [setLocale()](cci:1://file:///Users/zakyyudha/Projects/ramadan-cli/src/i18n/index.ts:17:0-24:2), [getLocale()](cci:1://file:///Users/zakyyudha/Projects/ramadan-cli/src/i18n/index.ts:26:0-26:58), [t()](cci:1://file:///Users/zakyyudha/Projects/ramadan-cli/src/i18n/index.ts:28:0-41:2) (translation with template interpolation)
- [src/i18n/locales/en.ts](cci:7://file:///Users/zakyyudha/Projects/ramadan-cli/src/i18n/locales/en.ts:0:0-0:0) — English locale (~120 translatable string keys)
- [src/i18n/locales/id.ts](cci:7://file:///Users/zakyyudha/Projects/ramadan-cli/src/i18n/locales/id.ts:0:0-0:0) — Indonesian locale with natural Bahasa Indonesia translations
- [src/__tests__/i18n.test.ts](cci:7://file:///Users/zakyyudha/Projects/ramadan-cli/src/__tests__/i18n.test.ts:0:0-0:0) — 10 unit tests for locale switching, interpolation, and fallback

### Modified files
- [cli.ts](cci:7://file:///Users/zakyyudha/Projects/ramadan-cli/src/cli.ts:0:0-0:0) — Added `-l, --lang` flag, early locale detection before `program.parse()`
- [setup.ts](cci:7://file:///Users/zakyyudha/Projects/ramadan-cli/src/setup.ts:0:0-0:0) — Language selection as first prompt in interactive setup
- [commands/ramadan.ts](cci:7://file:///Users/zakyyudha/Projects/ramadan-cli/src/commands/ramadan.ts:0:0-0:0) — All user-facing strings use [t()](cci:1://file:///Users/zakyyudha/Projects/ramadan-cli/src/i18n/index.ts:28:0-41:2) calls; fixed Hijri day alignment with roza number
- [commands/config.ts](cci:7://file:///Users/zakyyudha/Projects/ramadan-cli/src/commands/config.ts:0:0-0:0) — `--lang` support for persistent language preference, language shown in `--show`
- [ui/banner.ts](cci:7://file:///Users/zakyyudha/Projects/ramadan-cli/src/ui/banner.ts:0:0-0:0) — Translated banner label and tagline
- [ramadan-config.ts](cci:7://file:///Users/zakyyudha/Projects/ramadan-cli/src/ramadan-config.ts:0:0-0:0) — Added `language` field with [getStoredLanguage()](cci:1://file:///Users/zakyyudha/Projects/ramadan-cli/src/ramadan-config.ts:195:0-202:2) / [setStoredLanguage()](cci:1://file:///Users/zakyyudha/Projects/ramadan-cli/src/ramadan-config.ts:204:0-206:2)
- [index.ts](cci:7://file:///Users/zakyyudha/Projects/ramadan-cli/src/index.ts:0:0-0:0) — Export i18n module
- [readme.md](cci:7://file:///Users/zakyyudha/Projects/ramadan-cli/readme.md:0:0-0:0) — Documented language feature, flags, and usage

## Usage

```sh
# One-off language switch
ramadan-cli --lang id

# Save preferred language
ramadan-cli config --lang id

# First-run setup prompts for language selection
ramadan-cli