### PR TITLE
fix: add Kosovo country support and correct Pristina iftar time

### DIFF
--- a/src/__tests__/recommendations.test.ts
+++ b/src/__tests__/recommendations.test.ts
@@ -19,4 +19,17 @@ describe('recommendations', () => {
 		expect(getRecommendedSchool('Pakistan')).toBe(1);
 		expect(getRecommendedSchool('Canada')).toBe(0);
 	});
+
+	it('returns method 13 (Diyanet) for Kosovo', () => {
+		expect(getRecommendedMethod('Kosovo')).toBe(13);
+		expect(getRecommendedMethod('Kosova')).toBe(13);
+		expect(getRecommendedMethod('Republic of Kosovo')).toBe(13);
+		expect(getRecommendedMethod('kosovo')).toBe(13);
+	});
+
+	it('returns Hanafi school for Kosovo', () => {
+		expect(getRecommendedSchool('Kosovo')).toBe(1);
+		expect(getRecommendedSchool('Kosova')).toBe(1);
+		expect(getRecommendedSchool('Republic of Kosovo')).toBe(1);
+	});
 });

--- a/src/recommendations.ts
+++ b/src/recommendations.ts
@@ -48,6 +48,9 @@ const countryMethodMap: Readonly<Record<string, number>> = {
 	France: 12,
 	Turkey: 13,
 	Türkiye: 13,
+	Kosovo: 13,
+	Kosova: 13,
+	'Republic of Kosovo': 13,
 	Russia: 14,
 	'United Arab Emirates': 16,
 	UAE: 16,
@@ -76,6 +79,9 @@ const hanafiCountries = new Set<string>([
 	'Tajikistan',
 	'Turkmenistan',
 	'Kyrgyzstan',
+	'Kosovo',
+	'Kosova',
+	'Republic of Kosovo',
 ]);
 
 export const getRecommendedMethod = (country: string): number | null => {


### PR DESCRIPTION
Fix #29 
Kosovo was missing from the country recommendation maps in src/recommendations.ts, causing two bugs:

Kosovo not recognized — getRecommendedMethod('Kosovo') returned null, so no method was auto-recommended during setup Iftar ~2 minutes early in Pristina — without a recognized country, the Aladhan API was called without the correct calculation method, producing inaccurate Maghrib times

Fixed:
The Islamic Community of Kosovo (BIK — Bashkësia Islame e Kosovës) officially uses the Turkey Diyanet method (method 13) for prayer time calculations, consistent with the broader Balkan region. Kosovo's ~95% Muslim population follows the Hanafi school.

Added Kosovo, Kosova (Albanian name), and Republic of Kosovo to:

countryMethodMap → method 13 hanafiCountries → school 1 (Hanafi)

Tests:
Added 2 new test cases covering method and school recommendation for all three Kosovo name variants. All 40 tests pass.