### PR TITLE
fix: show readable method and school names in config output

### DIFF
--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -10,6 +10,7 @@ import {
 	setStoredSchool,
 	setStoredTimezone,
 } from '../ramadan-config.js';
+import { findMethodLabel, findSchoolLabel } from '../setup.js';
 
 export interface ConfigCommandOptions {
 	readonly city?: string | undefined;
@@ -135,8 +136,8 @@ const printCurrentConfig = (): void => {
 	if (location.longitude !== undefined) {
 		console.log(`  Longitude: ${location.longitude}`);
 	}
-	console.log(`  Method: ${settings.method}`);
-	console.log(`  School: ${settings.school}`);
+	console.log(`  Method: ${findMethodLabel(settings.method)}`);
+	console.log(`  School: ${findSchoolLabel(settings.school)}`);
 	if (settings.timezone) {
 		console.log(`  Timezone: ${settings.timezone}`);
 	}

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -91,13 +91,24 @@ const toTimezoneChoice = (
 	return null;
 };
 
-const findMethodLabel = (method: number): string => {
+export const findMethodLabel = (method: number): string => {
 	const option = METHOD_OPTIONS.find((entry) => entry.value === method);
 	if (option) {
 		return option.label;
 	}
 
 	return `Method ${method}`;
+};
+
+export const findSchoolLabel = (school: number): string => {
+	if (school === SCHOOL_SHAFI) {
+		return 'Shafi';
+	}
+	if (school === SCHOOL_HANAFI) {
+		return 'Hanafi';
+	}
+
+	return `School ${school}`;
 };
 
 export const getMethodOptions = (


### PR DESCRIPTION
Update config --show to print mapped method/school labels instead of numeric IDs, and export shared label helpers from setup for reuse.